### PR TITLE
Add dark mode theme toggle functionality

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -24,6 +24,7 @@
                 </div>
                 <div id="containerHeaderRight">
                     <div id="containerLanguageSelection"></div>
+                    <button id="btnThemeToggle"></button>
                 </div>
             </div>
 

--- a/www/main.js
+++ b/www/main.js
@@ -1,6 +1,7 @@
 import { Persistence } from "./modules/persistence.js";
 import { Logic } from "./modules/logic.js";
 import { Language } from "./modules/language.js";
+import { Theme } from "./modules/theme.js";
 import { UI } from "./modules/ui.js";
 import { registerServiceworker } from "./modules/registerServiceworker.js";
 import { ALL_TRANSLATIONS } from "./translations.js";
@@ -13,6 +14,8 @@ const language = new Language(
     navigator.languages
 );
 
-const ui = new UI(new Logic(new Persistence()), language);
+const theme = new Theme();
+
+const ui = new UI(new Logic(new Persistence()), language, theme);
 
 registerServiceworker(ui)

--- a/www/modules/theme.js
+++ b/www/modules/theme.js
@@ -1,0 +1,56 @@
+/**
+ * Theme class
+ */
+export class Theme {
+    #theme;
+    #localStorage;
+    #onThemeChangeCallbacks = [];
+
+    static THEMES = { LIGHT: "light", DARK: "dark" };
+
+    /**
+     * @param {Storage} localStorage
+     */
+    constructor(localStorage = window.localStorage) {
+        this.#localStorage = localStorage;
+        const stored = this.#localStorage.getItem("theme");
+        if (stored === Theme.THEMES.DARK || stored === Theme.THEMES.LIGHT) {
+            this.theme = stored;
+        } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+            this.theme = Theme.THEMES.DARK;
+        } else {
+            this.theme = Theme.THEMES.LIGHT;
+        }
+    }
+
+    get theme() {
+        return this.#theme;
+    }
+
+    get isDark() {
+        return this.#theme === Theme.THEMES.DARK;
+    }
+
+    /**
+     * @param {string} value
+     */
+    set theme(value) {
+        this.#theme = value;
+        this.#localStorage.setItem("theme", value);
+        document.documentElement.setAttribute("data-theme", value);
+        for (const callback of this.#onThemeChangeCallbacks) {
+            callback(value);
+        }
+    }
+
+    toggle() {
+        this.theme = this.isDark ? Theme.THEMES.LIGHT : Theme.THEMES.DARK;
+    }
+
+    /**
+     * @param {(theme: string) => void} callback
+     */
+    addThemeChangeListener(callback) {
+        this.#onThemeChangeCallbacks.push(callback);
+    }
+}

--- a/www/modules/theme.js
+++ b/www/modules/theme.js
@@ -1,11 +1,18 @@
 /**
+ * @typedef {"light" | "dark"} ThemeValue
+ */
+
+/**
  * Theme class
  */
 export class Theme {
+    /** @type {ThemeValue} */
     #theme;
     #localStorage;
+    /** @type {Array<(theme: ThemeValue) => void>} */
     #onThemeChangeCallbacks = [];
 
+    /** @type {Readonly<{LIGHT: "light", DARK: "dark"}>} */
     static THEMES = { LIGHT: "light", DARK: "dark" };
 
     /**
@@ -23,18 +30,27 @@ export class Theme {
         }
     }
 
+    /**
+     * @returns {ThemeValue}
+     */
     get theme() {
         return this.#theme;
     }
 
+    /**
+     * @returns {boolean}
+     */
     get isDark() {
         return this.#theme === Theme.THEMES.DARK;
     }
 
     /**
-     * @param {string} value
+     * @param {ThemeValue} value
      */
     set theme(value) {
+        if (value !== Theme.THEMES.LIGHT && value !== Theme.THEMES.DARK) {
+            throw new Error(`Invalid theme: ${value}. Must be "${Theme.THEMES.LIGHT}" or "${Theme.THEMES.DARK}".`);
+        }
         this.#theme = value;
         this.#localStorage.setItem("theme", value);
         document.documentElement.setAttribute("data-theme", value);
@@ -48,7 +64,7 @@ export class Theme {
     }
 
     /**
-     * @param {(theme: string) => void} callback
+     * @param {(theme: ThemeValue) => void} callback
      */
     addThemeChangeListener(callback) {
         this.#onThemeChangeCallbacks.push(callback);

--- a/www/modules/ui.js
+++ b/www/modules/ui.js
@@ -7,15 +7,18 @@ import { toPaddedString } from "./utils/number.js";
 export class UI {
     #logic;
     #language;
+    #theme;
     #elems;
 
     /**
      * @param {import("./logic").Logic} logic
      * @param {import("./language").Language} language
+     * @param {import("./theme").Theme} theme
      */
-    constructor(logic, language) {
+    constructor(logic, language, theme) {
         this.#logic = logic;
         this.#language = language;
+        this.#theme = theme;
 
         this.#elems = {
             btnAddStamp: document.getElementById("btnAddStamp"),
@@ -50,6 +53,7 @@ export class UI {
             containerLanguageSelection: document.getElementById("containerLanguageSelection"),
             spanAppVersion: document.getElementById("spanAppVersion"),
             footerText: document.getElementById("footerText"),
+            btnThemeToggle: document.getElementById("btnThemeToggle"),
         };
 
         this.bindInitialDomEvents();
@@ -57,6 +61,10 @@ export class UI {
         this.#language.addLanguageChangeListener(() => {
             this.refreshInitialView();
         })
+
+        this.#theme.addThemeChangeListener(() => {
+            this.refreshThemeToggle();
+        });
 
         this.refreshInitialView();
     }
@@ -120,6 +128,9 @@ export class UI {
         this.#elems.btnDownloadStampsCsv.addEventListener("click", () => {
             this.downloadStampCsv();
         });
+        this.#elems.btnThemeToggle.addEventListener("click", () => {
+            this.#theme.toggle();
+        });
     }
 
     refreshInitialView() {
@@ -127,6 +138,14 @@ export class UI {
         this.refreshStampList();
         this.refreshInitialViewTexts();
         this.refreshLanguageSelection();
+        this.refreshThemeToggle();
+    }
+
+    refreshThemeToggle() {
+        this.#elems.btnThemeToggle.textContent = this.#theme.isDark ? "\u2600\uFE0F" : "\uD83C\uDF19";
+        this.#elems.btnThemeToggle.title = this.#theme.isDark
+            ? this.#language.t("lightMode")
+            : this.#language.t("darkMode");
     }
 
     refreshInitialViewTexts() {

--- a/www/offlineFiles.js
+++ b/www/offlineFiles.js
@@ -20,6 +20,7 @@ const OFFLINE_FILES = [
   "/modules/model.js",
   "/modules/persistence.js",
   "/modules/registerServiceworker.js",
+  "/modules/theme.js",
   "/modules/ui.js",
   "/modules/utils/download.js",
   "/modules/utils/number.js"

--- a/www/style.css
+++ b/www/style.css
@@ -36,6 +36,40 @@
     color: var(--color-text);
 }
 
+[data-theme="dark"] {
+    --color-text: #e0e0f0;
+    --color-white: #1e1e2e;
+    --color-bg: #12121a;
+    --color-arrive: #2ecc71;
+    --color-arrive-hover: #27ae60;
+    --color-leave: #e74c3c;
+    --color-leave-hover: #c0392b;
+    --color-neutral: #2a2a3e;
+    --color-neutral-hover: #33334a;
+    --color-border: #3a3a50;
+    --color-border-light: #4a4a60;
+    --color-text-muted: #9090a8;
+    --color-accent: #6b8cff;
+    --color-accent-hover: #5a7bf0;
+    --color-danger-bg: #3a1a1a;
+    --color-danger-bg-hover: #4a2020;
+    --color-danger-border: #6a3030;
+    --color-danger-border-hover: #804040;
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.3);
+    --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.4);
+    --shadow-accent-focus: 0 0 0 3px rgba(107, 140, 255, 0.25);
+    --shadow-accent-subtle: rgba(107, 140, 255, 0.15);
+    --shadow-arrive: 0 4px 12px rgba(46, 204, 113, 0.25);
+    --shadow-arrive-sm: 0 2px 8px rgba(46, 204, 113, 0.25);
+    --shadow-leave: 0 4px 12px rgba(231, 76, 60, 0.25);
+    --shadow-leave-sm: 0 2px 8px rgba(231, 76, 60, 0.25);
+    --color-separator: rgba(255, 255, 255, 0.06);
+    --color-overlay: rgba(0, 0, 0, 0.6);
+    --color-overlay-light: rgba(0, 0, 0, 0.5);
+    color-scheme: dark;
+}
+
 body {
     margin: 0;
     padding: 0;
@@ -537,6 +571,23 @@ button:active {
 #footerText {
     font-size: 0.75rem;
     color: var(--color-text-muted);
+}
+
+#btnThemeToggle {
+    font-size: 1.5rem;
+    padding: 0.15rem 0.4rem;
+    margin: 0;
+    margin-left: 0.5em;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-neutral);
+    border-radius: 50%;
+    box-shadow: none;
+    line-height: 1;
+}
+
+#btnThemeToggle:hover {
+    background-color: var(--color-neutral-hover);
+    box-shadow: var(--shadow-sm);
 }
 
 @media (max-width: 320px) {

--- a/www/translations.js
+++ b/www/translations.js
@@ -37,8 +37,8 @@ const TRANSLATION_EN = {
     exportCsv: "Export to CSV",
     deleteAllStampsConfirmationMessage: "Are you sure you want to delete all records?",
     deleteStamp: "Delete record",
-    darkMode: "Dark mode",
-    lightMode: "Light mode",
+    darkMode: "Change to dark mode",
+    lightMode: "Change to light mode",
 }
 
 /**
@@ -80,8 +80,8 @@ const TRANSLATION_FI = {
     welcomeText: "Tervetuloa käyttämään Pulkka työleimaussovellusta!",
     close: "Sulje",
     exportCsv: "Vie CSV-tiedostoon",
-    darkMode: "Tumma teema",
-    lightMode: "Vaalea teema",
+    darkMode: "Vaihda tummaan teemaan",
+    lightMode: "Vaihda vaaleaan teemaan",
 }
 
 /**

--- a/www/translations.js
+++ b/www/translations.js
@@ -37,6 +37,8 @@ const TRANSLATION_EN = {
     exportCsv: "Export to CSV",
     deleteAllStampsConfirmationMessage: "Are you sure you want to delete all records?",
     deleteStamp: "Delete record",
+    darkMode: "Dark mode",
+    lightMode: "Light mode",
 }
 
 /**
@@ -78,6 +80,8 @@ const TRANSLATION_FI = {
     welcomeText: "Tervetuloa käyttämään Pulkka työleimaussovellusta!",
     close: "Sulje",
     exportCsv: "Vie CSV-tiedostoon",
+    darkMode: "Tumma teema",
+    lightMode: "Vaalea teema",
 }
 
 /**

--- a/www/version.js
+++ b/www/version.js
@@ -1,1 +1,1 @@
-const VERSION = "0.3.0"
+const VERSION = "0.4.0"


### PR DESCRIPTION
## Summary
This PR adds a dark mode theme toggle feature to the application, allowing users to switch between light and dark themes with persistent storage of their preference.

## Key Changes
- **New Theme Module** (`www/modules/theme.js`): Created a `Theme` class that manages theme state with the following features:
  - Detects user's system color scheme preference on initialization
  - Persists theme selection to localStorage
  - Provides theme toggle functionality
  - Supports theme change callbacks for reactive UI updates
  - Defines two theme constants: `LIGHT` and `DARK`

- **Dark Theme Styles** (`www/style.css`): Added comprehensive dark mode CSS variables with:
  - Dark color palette for text, backgrounds, and UI elements
  - Adjusted shadows and overlays for dark mode
  - Proper contrast ratios for accessibility
  - Applied via `[data-theme="dark"]` selector

- **UI Integration** (`www/modules/ui.js`):
  - Added theme toggle button to the header
  - Button displays sun (☀️) or moon (🌙) emoji based on current theme
  - Localized button tooltips ("Dark mode" / "Light mode")
  - Listens to theme changes and updates button state accordingly

- **Translations** (`www/translations.js`): Added localization strings for theme toggle in English and Finnish

- **HTML Structure** (`www/index.html`): Added theme toggle button element in the header's right container

- **Main Application** (`www/main.js`): Instantiated Theme module and passed it to UI constructor

## Implementation Details
- Theme preference is stored in localStorage under the "theme" key
- On initialization, the theme respects: stored preference → system preference → light mode default
- The `data-theme` attribute on the document root element controls which CSS variables are applied
- Theme changes trigger callbacks that update the UI, enabling reactive theme switching
- The implementation uses private fields (`#`) for encapsulation

https://claude.ai/code/session_01WUvLQh9N7arVbiNsWZpFZv