### PR TITLE
Add Dependabot config with 3-day cooldown for package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
+      interval: "monthly"
     cooldown:
-      default: 3
-      semver-major: 3
+      default-days: 3
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+    ignore:
+      # For all deps
+      - dependency-name: "*"
+        # ignore all major updates
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    cooldown:
+      default: 3
+      semver-major: 3

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-scripts=true


### PR DESCRIPTION
Configures Dependabot for npm with weekly checks, groups dependencies
by production/development, and sets a 3-day cooldown period to reduce
noise from rapid successive updates.

https://claude.ai/code/session_015xHNXgQ858XtBCGz6Y8476